### PR TITLE
Fix Load from previously crawled

### DIFF
--- a/engine/download.py
+++ b/engine/download.py
@@ -43,17 +43,21 @@ class Loader(PipelineElement):
         """
 
         self.cursor.execute("""
-            SELECT id, link, blob FROM crawled
+            SELECT link, blob FROM crawled
         """)
+
+        self.cursor.execute("TRUNCATE documents")
+        self.cursor.execute("TRUNCATE words")
+        self.cursor.execute("TRUNCATE TFs")
+        self.cursor.execute("TRUNCATE IDFs")
 
         row = self.cursor.fetchone()
         while row:
-            doc_id, link, blob = row
+            link, blob = row
 
             soup = pickle.loads(lzma.decompress(blob))
 
-            await self.propagate_to_next(soup, link, doc_id = doc_id)
+            await self.propagate_to_next(soup, link)
 
             row = self.cursor.fetchone()
 
-        self.cursor.execute("TRUNCATE crawled")

--- a/engine/setup.sql
+++ b/engine/setup.sql
@@ -14,8 +14,7 @@ CREATE SEQUENCE doc_ids START 1;
 CREATE SEQUENCE word_ids START 1;
 
 CREATE TABLE crawled (
-    id      INTEGER DEFAULT nextval('doc_ids') PRIMARY KEY,
-    link    VARCHAR UNIQUE NOT NULL,
+    link    VARCHAR PRIMARY KEY,
     content BLOB NOT NULL
 );
 


### PR DESCRIPTION
I was previously under the impression that `Indexer` and `Download` handle different links from the `Crawler` but the `Crawler` forwards the same link and soup to both `Indexer` and `Download`. Thus resulting in a `Loader` that then would try to load the _same_ link/documents into the DB thus violating the uniqueness constraint for the `link` column of the `document` table.

This PR deletes all entries from the `documents`, `words`, `TFs` and `IDFs` tables such that they can be indexed, tokenized and computed from the `crawled` table anew. Said table won't need a document id as it will be created by the `Indexer`.

Coinciding there is no need for distinguishing where the `Indexer` gets its data from as there is only one path.

As long as the `global.json` is not deleted the `crawled` table will fill up with all previously seen sites.